### PR TITLE
fix(select): Don't close on mouseup on scrollbar

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -1108,6 +1108,17 @@ function SelectProvider($$interimElementProvider) {
         function checkCloseMenu(ev) {
           if (ev && ( ev.type == 'mouseup') && (ev.currentTarget != dropDown[0])) return;
 
+          // check if the mouseup event was on a scrollbar
+          if(ev.currentTarget.children.length > 0) {
+            var child = ev.currentTarget.children[0];
+            var hasScrollbar = child.scrollHeight > child.clientHeight
+            if (hasScrollbar && child.children.length > 0) {
+              var relPosX = ev.pageX - ev.currentTarget.getBoundingClientRect().left;
+              if(relPosX > child.children[0].offsetWidth) 
+                return;
+            }
+          }
+          
           if (!selectCtrl.isMultiple) {
             opts.restoreFocus = true;
 


### PR DESCRIPTION
md-select does not auto-close anymore when the scrollbar is used to scroll the options.
Checked the event position in checkCloseMenu()
Testet on Windows: FF 40, Chrome 44, IE 11. Should be 
See issue #4078 'md-select with scrollbars auto closing'
